### PR TITLE
Fix comparison of URLs and request method.

### DIFF
--- a/lib/signed_form/action_controller/permit_signed_params.rb
+++ b/lib/signed_form/action_controller/permit_signed_params.rb
@@ -24,7 +24,15 @@ module SignedForm
         allowed_attributes = Marshal.load Base64.strict_decode64(data)
         options            = allowed_attributes.delete(:_options_)
 
-        raise Errors::InvalidURL if options && (!options[:method].to_s.casecmp(request.method) || options[:url] != request.fullpath)
+        if options
+          if options[:method].to_s.casecmp(request.request_method) != 0
+            raise Errors::InvalidURL
+          end
+          url = url_for(options[:url])
+          if url != request.fullpath and url != request.url
+            raise Errors::InvalidURL
+          end
+        end
 
         allowed_attributes.each do |k, v|
           params[k] = params.require(k).permit(*v)


### PR DESCRIPTION
- `String#casecmp` returns -1/0/1, not true/false
- use `request.request_method` instead of `request.method`, which contains the
  intended method, not the physically used one (PATCH vs. POST)
- call `url_for` on the url, and compare with both full url and path; this fixes
  the case where a symbol or array is specified as url in `signed_form_for`

After the first problem (casecmp) is fixed (which previously was always true), it can be seen that forms using PATCH or PUT don't work any more, because Rails turns this into a POST for compatibility reasons and store the actually wanted method in an additional parameter. This method can be read from request.request_method.

Second problem: If `signed_form_for` is called with an array or symbol, i.e.:
`signed_form_for @user, url: :settings ...`
The symbol itself is signed, not the actual URL/path. Thus, the comparison with the URL fails on verification. This is fixed by calling `url_for` on the signed url.

(I would have split this into seperate pull requests, but they all affect the same line.)
