### PR TITLE
Merge the fields for multiple `fields_for` calls

### DIFF
--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -310,6 +310,22 @@ describe SignedForm::FormBuilder do
       data = get_data_from_form(content)
       data[:author].size.should == 1
     end
+
+    specify "multiple fields_for should create one hash only" do
+      content = form_for(:author, url: '/', signed: true) do |f|
+        f.fields_for :books do |ff|
+          ff.text_field :name
+        end
+        f.fields_for :books do |ff|
+          ff.text_field :price
+        end
+        f.fields_for :pets do |ff|
+          ff.text_field :name
+        end
+      end
+      data = get_data_from_form(content)
+      data[:author].size.should == 1
+    end
   end
 
   describe "form digests" do


### PR DESCRIPTION
If `fields_for` is called several times for the same nested model, a structure
of the following form is constructed and signed:

```
{"user" => ["name", "email", {"pet_attributes" => [:name]}, {"pet_attributes" => [:species]}]}
```

Unfortunately, due to the way strong parameters work, only the attributes in
the last occurance of `"pet_attributes"` will be allowed.

This patch merges the hashes together to yield the following structure:

```
{"user" => [:name, :email, {"pet_attributes" => [:name, :species]}]}
```
