### PR TITLE
Make specs pass for Rails 4.1

### DIFF
--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -22,6 +22,7 @@ end
 
 class ControllerRenderer < AbstractController::Base
   include AbstractController::Rendering
+  include ActionView::Rendering if defined? ActionView::Rendering
   self.view_paths = [ActionView::FileSystemResolver.new(File.join(File.dirname(__FILE__), 'fixtures', 'views'))]
 
   view_context_class.class_eval do


### PR DESCRIPTION
AbstractController::Rendering isn't enough anymore due to the extraction of Action View
