### PR TITLE
Designate fields that submit multiple values correctly

### DIFF
--- a/lib/signed_form/form_builder.rb
+++ b/lib/signed_form/form_builder.rb
@@ -17,7 +17,7 @@ module SignedForm
 
     FIELDS_TO_SIGN.each do |kind|
       kind, v = kind.is_a?(Symbol) ? [kind, nil] : kind.first
-      define_method(kind) do |field, *args|
+      define_method(kind) do |field, *args, &block|
         options = args.last.is_a?(Hash) ? args.last : {}
         value = v.is_a?(Symbol) ? send(v, field, *args) : v
         unless options[:disabled]
@@ -27,7 +27,7 @@ module SignedForm
             add_signed_fields field
           end
         end
-        super(field, *args)
+        super(field, *args, &block)
       end
     end
 

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class User
   extend ActiveModel::Naming
 
-  attr_accessor :name, :widgets_attributes
+  attr_accessor :name, :options, :widgets_attributes
 
   def to_key
     [1]
@@ -127,6 +127,32 @@ describe SignedForm::FormBuilder do
         f.text_field :name
       end
 
+      @data = get_data_from_form(content)
+    end
+  end
+
+  describe "form collection inputs" do
+    after do
+      @data['user'].size.should == 1
+      @data['user'].should include({:options=>[]})
+    end
+
+    it "should add to the allowed attributes when collection_check_boxes is used", action_pack: /4\.\d+/ do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_check_boxes :options, ['a', 'b'], :to_s, :to_s
+      end
+
+      @data = get_data_from_form(content)
+    end
+
+    it 'should pass a given block to the input helper method' do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_check_boxes :options, ['a'], :to_s, :to_s, {}, {} do |b|
+          'teststring'
+        end
+      end
+
+      content.should include 'teststring'
       @data = get_data_from_form(content)
     end
   end

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -160,14 +160,6 @@ describe SignedForm::FormBuilder do
       end
     end
 
-    it "should add to the allowed attributes when collection_check_boxes is used", action_pack: /4\.\d+/ do
-      content = form_for(User.new, signed: true) do |f|
-        f.collection_check_boxes :name, ['a', 'b'], :to_s, :to_s
-      end
-
-      @data = get_data_from_form(content)
-    end
-
     it "should add to the allowed attributes when grouped_collection_select is used" do
       continent   = Struct.new('Continent', :continent_name, :countries)
       country     = Struct.new('Country', :country_id, :country_name)
@@ -253,6 +245,54 @@ describe SignedForm::FormBuilder do
 
       data = get_data_from_form(content)
       data["user"].should be_empty
+    end
+  end
+
+  describe "form inputs that submit multiple values" do
+    after do
+      @data['user'].size.should == 1
+      @data['user'].should_not include(:name)
+      @data['user'].should include({:name => []})
+    end
+
+    it "should add a hash with an empty array when collection_check_boxes is used", action_pack: /4\.\d+/ do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_check_boxes :name, ['a', 'b'], :to_s, :to_s
+      end
+
+      @data = get_data_from_form(content)
+    end
+
+    it "should add a hash with an empty array when collection_select(..., multiple: true) is used" do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_select :name, %w(a b), :to_s, :to_s, multiple: true
+      end
+
+      @data = get_data_from_form(content)
+    end
+  end
+
+  describe "form inputs that don't submit multiple values" do
+    after do
+      @data['user'].size.should == 1
+      @data['user'].should include(:name)
+      @data['user'].should_not include({:name => []})
+    end
+
+    it "shouldn't add a hash with an empty array when collection_radio_buttons is used", action_pack: /4\.\d+/ do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_radio_buttons :name, ['a', 'b'], :to_s, :to_s
+      end
+
+      @data = get_data_from_form(content)
+    end
+
+    it "shouldn't add a hash with an empty array when collection_select(..., multiple: false) is used" do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_select :name, %w(a b), :to_s, :to_s, multiple: false
+      end
+
+      @data = get_data_from_form(content)
     end
   end
 


### PR DESCRIPTION
Some fields can submit multiple values, i.e. use `[]` behind the name. These include `collection_check_boxes`, `select`, `collection_select`, and `grouped_collection_select`.

`strong_parameters` needs those to be designated specially, otherwise they won't be accepted:
```
add_signed_fields :user_ids => []
```
instead of
```
add_signed_fields :user_ids
```