### PR TITLE
Allow to provide blocks to form helper methods

### DIFF
--- a/lib/signed_form/form_builder.rb
+++ b/lib/signed_form/form_builder.rb
@@ -15,9 +15,9 @@ module SignedForm
     FIELDS_TO_SIGN.freeze
 
     FIELDS_TO_SIGN.each do |h|
-      define_method(h) do |field, *args|
+      define_method(h) do |field, *args, &block|
         add_signed_fields field
-        super(field, *args)
+        super(field, *args, &block)
       end
     end
 

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -168,6 +168,17 @@ describe SignedForm::FormBuilder do
       @data = get_data_from_form(content)
     end
 
+    it 'should pass a given block to the input helper method' do
+      content = form_for(User.new, signed: true) do |f|
+        f.collection_check_boxes :name, ['a'], :to_s, :to_s, {}, {} do |b|
+          'teststring'
+        end
+      end
+
+      content.should include 'teststring'
+      @data = get_data_from_form(content)
+    end
+
     it "should add to the allowed attributes when grouped_collection_select is used" do
       continent   = Struct.new('Continent', :continent_name, :countries)
       country     = Struct.new('Country', :country_id, :country_name)


### PR DESCRIPTION
Blocks are swallowed by the form_helper and not passed to the overridden methods.

This breaks e.g. simple_form's nested check boxes.