### PR TITLE
Ignore anchor in URL validation

### DIFF
--- a/lib/signed_form.rb
+++ b/lib/signed_form.rb
@@ -1,15 +1,17 @@
-require "action_view"
-require "action_controller"
+# frozen_string_literal: true
 
-require "signed_form/version"
-require "signed_form/errors"
-require "signed_form/form_builder"
-require "signed_form/hmac"
-require "signed_form/digest_stores"
-require "signed_form/digestor"
-require "signed_form/action_view/form_helper"
-require "signed_form/gate_keeper"
-require "signed_form/action_controller/permit_signed_params"
+require 'action_view'
+require 'action_controller'
+
+require 'signed_form/version'
+require 'signed_form/errors'
+require 'signed_form/form_builder'
+require 'signed_form/hmac'
+require 'signed_form/digest_stores'
+require 'signed_form/digestor'
+require 'signed_form/action_view/form_helper'
+require 'signed_form/gate_keeper'
+require 'signed_form/action_controller/permit_signed_params'
 
 module SignedForm
   DEFAULT_OPTIONS = {
@@ -34,6 +36,14 @@ module SignedForm
 
     def config
       yield self
+    end
+
+    def tokenize(attributes = {})
+      encoded_data = Base64.strict_encode64 Marshal.dump(attributes)
+      hmac = HMAC.new(secret_key: secret_key)
+      signature = hmac.create(encoded_data)
+
+      "#{encoded_data}--#{signature}"
     end
   end
 end

--- a/lib/signed_form/gate_keeper.rb
+++ b/lib/signed_form/gate_keeper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SignedForm
   class GateKeeper
     attr_reader :allowed_attributes
@@ -22,7 +24,7 @@ module SignedForm
 
       signature ||= ''
 
-      raise Errors::InvalidSignature, "Form signature is not valid" unless hmac.verify signature, data
+      raise Errors::InvalidSignature, 'Form signature is not valid' unless hmac.verify signature, data
 
       @allowed_attributes = Marshal.load Base64.strict_decode64(data)
       @options            = allowed_attributes.delete(:_options_)
@@ -31,7 +33,7 @@ module SignedForm
     def verify_destination
       return unless options[:method] && options[:url]
       raise Errors::InvalidURL if options[:method].to_s.casecmp(@request.request_method) != 0
-      url = @controller.url_for(options[:url])
+      url = @controller.url_for(options[:url]).split('#').first
       raise Errors::InvalidURL if url != @request.fullpath && url != @request.url
     end
 

--- a/spec/gate_keeper_spec.rb
+++ b/spec/gate_keeper_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SignedForm
+  RSpec.describe GateKeeper do
+    before do
+      SignedForm.config do |c|
+        c.secret_key = 'hunter2'
+      end
+    end
+
+    let :url do
+      'http://www.example.com/posts/1/comments/2'
+    end
+
+    let :controller do
+      attributes = { 'foo' => 'bar' }
+      double(
+        'Controller',
+        params: attributes.merge(
+          'form_signature' => SignedForm.tokenize(attributes)
+        ),
+        request: double(
+          'Request',
+          fullpath: url,
+          url: url,
+          request_method: 'GET'
+        ),
+        url_for: url
+      )
+    end
+
+    subject do
+      GateKeeper.new controller
+    end
+
+    it 'ignores anchor when verifying url' do
+      allow(subject).to receive(:options).and_return(
+        method: :get,
+        url: "#{url}#redirect_to=back"
+      )
+
+      expect(subject.verify_destination).to be(nil)
+    end
+
+    it 'raises error when url is invalid' do
+      allow(controller.request).to receive(:fullpath).and_return('foo')
+      allow(subject).to receive(:options).and_return(method: :get, url: url)
+
+      expect(subject.verify_destination).to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
Since the anchor portion of a URL is not processed by the server anyway,
it should not be taken into account when we validate the URL that the
form data is being sent to.

Fixes #27
