### PR TITLE
Only support Ruby 2.4.3/2.5.0 & Rails 5-2-stable/4-2-stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,15 @@ script: bundle exec rspec
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.4.3
+  - 2.5.0
 
 env:
-  - RAILS_VERSION=3-1-stable
-  - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION=4-1-stable
   - RAILS_VERSION=4-2-stable
+  - RAILS_VERSION=5-2-stable
   - RAILS_VERSION=master
 
 matrix:
   allow_failures:
     - env: RAILS_VERSION=master
+

--- a/Changes.md
+++ b/Changes.md
@@ -53,8 +53,7 @@ Released by Johnneylee Jack Rollins <Johnneylee.Rollins@gmail.com>
   Contributed by Marc Schütz <schuetzm@gmx.net>
 
 * ActiveAdmin integration  
-  CSchramm has created a plugin that integrates both activeadmin and  
-  signed_form  
+  CSchramm has created a plugin that integrates both activeadmin and signed_form  
   Contributed by Christopher Schramm <cschramm@shakaweb.org>
 
 * Tests pass under Rails 4.1  

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ when /master/
 when /-stable$/
   gem 'rails', github: 'rails/rails', branch: rails_version
 else
-  gem 'rails', ENV['RAILS_VERSION']
+  gem 'rails', rails_version
 end

--- a/README.md
+++ b/README.md
@@ -6,33 +6,38 @@
 [![Coverage Status](https://coveralls.io/repos/erichmenge/signed_form/badge.png?branch=master)](https://coveralls.io/r/erichmenge/signed_form)
 [![Inline docs](http://inch-ci.org/github/erichmenge/signed_form.svg?branch=master&style=flat)](https://inch-ci.org/github/erichmenge/signed_form)
 
-SignedForm brings new convenience and security to your Rails 4 or Rails 3 application.
+SignedForm brings new convenience and security to your Rails 5 or Rails 4  
+application.
 
-SignedForm is under active development. Please make sure you're reading the README associated with the version of
-SignedForm you're using. Click the tag link on GitHub to switch to the version you've installed to get the correct
+SignedForm is under active development. Please make sure you're reading the  
+README associated with the version of SignedForm you're using. Click the tag  
+link on GitHub to switch to the version you've installed to get the correct  
 README.
 
 Or be brave and bundle the gem straight from GitHub master.
 
-A nicely displayed version of this README complete with table of contents is available
-[here](http://erichmenge.com/signed_form/).
+A nicely displayed version of this README complete with table of contents is  
+available [here](http://erichmenge.com/signed_form/).
 
 ## How It Works
 
-Traditionally, when you create a form with Rails you enter your fields using something like `f.text_field :name` and so
-on.  Once you're done making your form you need to make sure that you've either set those parameters as accessible in
-the model (Rails 3) or use `permit` (Rails 4). This is redundant. Why would you make a form for a user to fill out and
-then not accept their input? You need to always maintain this synchronization.
+Traditionally, when you create a form with Rails you enter your fields using  
+something like `f.text_field :name` and so on.  Once you're done making your  
+form you need to make sure that you've set those parameters as accessible in the  
+model (Rails 3) or use `permit` (Rails 4). This is redundant. Why would you make  
+a form for a user to fill out and then not accept their input? You need to  
+always maintain this synchronization.
 
-SignedForm generates a list of attributes that you have in your form and attaches them to be submitted with the form
-along with a HMAC-SHA1 signature of those attributes to protect them from tampering. That means no more `permit` and
+SignedForm generates a list of attributes that you have in your form and  
+attaches them to be submitted with the form along with a HMAC-SHA1 signature of  
+those attributes to protect them from tampering. That means no more `permit` and  
 no more `attr_accessible`. It just works.
 
 What this looks like:
 
 ```erb
 <%= form_for @user, signed: true do |f| %>
-  <% f.add_signed_fields :zipcode, :state # Optionally add additional fields to sign %>
+  <% f.add_signed_fields :zipcode, :state # add additional fields to sign %>
 
   <%= f.text_field :name %>
   <%= f.text_field :address %>
@@ -60,10 +65,11 @@ Disabled fields need to be explicitly signed:
 <% end %>
 ```
 
-That's it. You're done. Need to add a field? Pop it in the form. You don't need to then update a list of attributes.
+That's it. You're done. Need to add a field? Pop it in the form. You don't need  
+to then update a list of attributes.
 
-Of course, you're free to continue using the standard `form_for`. `SignedForm` is strictly opt-in. It won't change the
-way you use standard forms.
+Of course, you're free to continue using the standard `form_for`. `SignedForm`  
+is strictly opt-in. It won't change the way you use standard forms.
 
 ## Is it any good?
 
@@ -73,20 +79,23 @@ Yes.
 
 SignedForm protects you in 3 ways:
 
-* Form fields are signed, so no alteration of the fields are allowed.
-* Form actions are signed. That means a form with an action of `/admin/users/3` will not work when submitted to `/users/3`.
-* Form views are digested (see below). So if you remove a field from your form, old forms will not be accepted despite
-  a valid signature.
+* Form fields are signed, so no alteration of the fields are allowed.  
+* Form actions are signed. That means a form with an action of `/admin/users/3`  
+  will not work when submitted to `/users/3`.
+* Form views are digested (see below). So if you remove a field from your form,  
+  old forms will not be accepted despite a valid signature.
 
-The second two methods of security are optional and can be turned off globally or on a form by form basis.
+The second two methods of security are optional and can be turned off globally  
+or on a form by form basis.
 
 ## Requirements
 
 SignedForm requires:
 
-* Ruby 1.9 or later
-* Rails 4 or Rails 3.1+ ([strong_parameters](https://github.com/rails/strong_parameters) gem
-  required for Rails 3)
+* Ruby 2.4.3 or 2.5.0
+* Rails 4.2-stable, Rails 5.2-stable, or Rails master
+
+[strong_parameters]: https://github.com/rails/strong_parameters
 
 ## Installation
 
@@ -100,13 +109,9 @@ And then execute:
 
     $ bundle
 
-If you're using Rails 3, you'll also need to install the [strong_parameters](https://github.com/rails/strong_parameters)
-gem. Please set it up as instructed on the linked GitHub repo.
-
-If you're using Rails 4, it works out of the box.
-
-You'll need to include `SignedForm::ActionController::PermitSignedParams` in the controller(s) you want to use
-SignedForm with. This can be done application wide by adding the `include` to your ApplicationController.
+You'll need to include `SignedForm::ActionController::PermitSignedParams` in the  
+controller(s) you want to use SignedForm with. This can be done application wide  
+by adding the `include` to your ApplicationController.
 
 ```ruby
 ApplicationController < ActionController::Base
@@ -116,19 +121,10 @@ ApplicationController < ActionController::Base
 end
 ```
 
-On Rails versions older than 4.1, you'll also need to create an initializer:
-
-```shell
-$ echo "SignedForm.secret_key = '$(rake secret)'" > config/initializers/signed_form.rb
-```
-
-You'll probably want to keep this out of version control. Treat this key like you would your session secret, keep it
-private.
-
 ## Support for other Builders
 
-Any form that wraps `form_for` and the default field helpers will work with SignedForm. For example, a signed SimpleForm
-might look like this:
+Any form that wraps `form_for` and the default field helpers will work with  
+SignedForm. For example, a signed SimpleForm might look like this:
 
 ```erb
 <%= simple_form_for @user, signed: true do |f| %>
@@ -138,7 +134,8 @@ might look like this:
 
 This will create a signed form as expected.
 
-For builders that don't use the standard field helpers under the hood, you can create an adapter like this:
+For builders that don't use the standard field helpers under the hood, you can  
+create an adapter like this:
 
 ```ruby
 class MyAdapter < SomeOtherBuilder
@@ -161,31 +158,38 @@ Then in your view:
 
 ## ActiveAdmin support
 
-Gem [`signed_form-activeadmin`](https://github.com/cschramm/signed_form-activeadmin) integrates SignedForm with Active Admin.
+Gem
+[`signed_form-activeadmin`][] integrates SignedForm with Active Admin.
 
+[`signed_form-activeadmin`]: https://github.com/cschramm/signed_form-activeadmin
 ## Form Digests
 
-SignedForm will create a digest of all the views/partials involved with rendering your form. If the form is modifed old
-forms will be expired. This is done to eliminate the possibility of old forms coming back to bite you.
+SignedForm will create a digest of all the views/partials involved with  
+rendering your form. If the form is modifed old forms will be expired. This is  
+done to eliminate the possibility of old forms coming back to bite you.
 
-By default, there is a 5 minute grace period before old forms will be rejected. This is done so that if you make a
-trivial change to a form you won't prevent a form a user is currently filling out from being accepted when you
-restart your server.
+By default, there is a 5 minute grace period before old forms will be rejected.  
+This is done so that if you make a trivial change to a form you won't prevent a  
+form a user is currently filling out from being accepted when you restart your  
+server.
 
-Of course if a critical mistake is made (such as allowing an admin field to be set in the form) you could change the
-secret key to prevent any old form from getting through.
+Of course if a critical mistake is made (such as allowing an admin field to be  
+set in the form) you could change the secret key to prevent any old form from  
+getting through.
 
-By default, these digests are not cached. That means that each form that is submitted will have the views be digested
-again. Most views and partials are relatively small so the cost of computing the MD5 hash of the files is not very
-expensive. However, if this is something you care about SignedForm also provides a memory store
-(`SignedForm::DigestStores::MemoryStore`) that will cache the digests in memory. Other stores could be used as well, as
-long as the object responds to `#fetch` taking the cache key as an argument as well as the block that will return the
-digest.
+By default, these digests are not cached. That means that each form that is  
+submitted will have the views be digested again. Most views and partials are  
+relatively small so the cost of computing the MD5 hash of the files is not very  
+expensive. However, if this is something you care about SignedForm also provides  
+a memory store (`SignedForm::DigestStores::MemoryStore`) that will cache the  
+digests in memory. Other stores could be used as well, as long as the object  
+responds to `#fetch` taking the cache key as an argument as well as the block  
+that will return the digest.
 
 ## Example Configuration
 
-An example config/initializers/signed_form.rb might look something like this (these are the defaults, with the exception
-of the key of course):
+An example config/initializers/signed_form.rb might look something like this  
+(these are the defaults, with the exception of the key of course):
 
 ```ruby
 SignedForm.config do |c|
@@ -199,19 +203,22 @@ SignedForm.config do |c|
 end
 ```
 
-Those options that are in the options hash are the default per-form options. They can be overridden by passing the same
-option to the `form_for` method.
+Those options that are in the options hash are the default per-form options.  
+They can be overridden by passing the same option to the `form_for` method.
 
 ## Testing Your Controllers
 
-Because your tests won't include a signature you will get a `ForbiddenAttributes` exception in your tests that do mass
-assignment. SignedForm includes a test helper method, `permit_all_parameters` that works with both TestUnit and RSpec.
+Because your tests won't include a signature you will get a  
+`ForbiddenAttributes` exception in your tests that do mass assignment.  
+SignedForm includes a test helper method, `permit_all_parameters` that works  
+with both TestUnit and RSpec.
 
-In your `spec_helper` file or `test_helper` file `require 'signed_form/test_helper'`. Then `include
-SignedForm::TestHelper` in tests where you need it. An example is below.
+Add  `require 'signed_form/test_helper'` and `include SignedForm::TestHelper`  
+wherever appropriate for your tests. An example is below.
 
-**Caution**: `permit_all_parameters` without a block modifies the singleton class of the controller under test which
-lasts for the duration of the test. If you want `permit_all_parameters` to be limited to a specific part of the test,
+**Caution**: `permit_all_parameters` without a block modifies the singleton  
+class of the controller under test which lasts for the duration of the test. If  
+you want `permit_all_parameters` to be limited to a specific part of the test,  
 pass it a block and only that block will be affected. Example:
 
 ```ruby
@@ -259,8 +266,11 @@ end
 
 ## I want to hear from you
 
-If you're using SignedForm, I'd love to hear from you. What do you like? What could be better? I'd love to hear your
-ideas. Join the mailing list on librelist to join the discussion at [signedform@librelist.com](mailto:signedform@librelist.com).
+If you're using SignedForm, I'd love to hear from you. What do you like? What  
+could be better? I'd love to hear your ideas. Join the mailing list on librelist  
+to join the discussion at [signedform@librelist.com][].
+
+[signedform@librelist.com]: mailto:signedform@librelist.com
 
 ## Contributing
 

--- a/signed_form.gemspec
+++ b/signed_form.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.13"
   spec.add_development_dependency "activemodel", ">= 4.2"
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "byebug"
 
   spec.add_dependency "actionpack", ">= 4.2"
   spec.add_dependency "psych", ">= 2.0"

--- a/signed_form.gemspec
+++ b/signed_form.gemspec
@@ -21,11 +21,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.13"
-  spec.add_development_dependency "activemodel", ">= 3.1"
+  spec.add_development_dependency "activemodel", ">= 4.2"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "byebug"
 
-  spec.add_dependency "actionpack", ">= 3.1"
+  spec.add_dependency "actionpack", ">= 4.2"
+  spec.add_dependency "psych", ">= 2.0"
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = '>= 2.4'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'action_controller'
 require 'active_model'
 require 'action_controller'
 require 'active_support/core_ext'
-require 'byebug'
 
 require 'coveralls'
 Coveralls.wear! do


### PR DESCRIPTION
This is a highly breaking change for anyone left out, obviously.

I think that, going forward, that `signed_form` should only support the latest  
two stable branches of Ruby and Rails. There is a [legacy][] branch that is  
currently branched from the current tip of master, [v0.5.0][] that any backports  
can be sent to. As of this time, the legacy branch needs some work, but I don't  
see that as any kind of blocker for us moving forward.

I'll add tags for legacy issues. I'm going to merge this to get us green, but  
please, any input is welcomed.

[legacy]: https://github.com/erichmenge/signed_form/tree/legacy
[v0.5.0]: https://github.com/erichmenge/signed_form/tree/v0.5.0